### PR TITLE
Add CBV to enable easier composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,22 @@ class CustomUserAdmin(UserAdmin):
 
     download.short_description = "Download selected users"
 ```
+
+Example CBV
+
+```python
+class UserDownloadView(CsvDownloadView):
+    """Staff-only user downloads view."""
+
+    def is_permitted(self, request):
+        return request.user.is_staff
+
+    def filename(self, request):
+        return "users.csv"
+
+    def columns(self, request):
+        return ("first_name", "last_name", "email")
+
+    def queryset(self, request):
+        return User.objects.all()
+```

--- a/django_csv/views.py
+++ b/django_csv/views.py
@@ -33,6 +33,10 @@ class CsvDownloadView(View):
         """Return True if the download is permitted."""
         raise NotImplementedError()
 
+    def user(self, request: HttpRequest) -> settings.AUTH_USER_MODEL:
+        """Return the user against whom to record the download."""
+        return request.user
+
     def filename(self, request: HttpRequest) -> str:
         """Return download filename."""
         raise NotImplementedError()
@@ -50,7 +54,7 @@ class CsvDownloadView(View):
         if not self.is_permitted(request):
             return HttpResponseForbidden()
         return download_csv(
-            request.user,
+            self.user(request),
             self.filename(request),
             self.queryset(request),
             *self.columns(request),

--- a/django_csv/views.py
+++ b/django_csv/views.py
@@ -28,11 +28,8 @@ class DownloadForbidden(Exception):
     pass
 
 
-class DownloadCsv(View):
+class DownloadCsvView(View):
     """CBV for downloading CSVs."""
-
-    # list of columns to be extracted from the queryset
-    csv_columns = []
 
     def authorize(self, request: HttpRequest) -> None:
         """
@@ -50,21 +47,23 @@ class DownloadCsv(View):
         """Return download filename."""
         raise NotImplementedError()
 
+    def columns(self, request: HttpRequest) -> str:
+        """Return columns to extract from the queryset."""
+        raise NotImplementedError()
+
     def queryset(self, request: HttpRequest) -> QuerySet:
         """Fetch the appropriate data for the user."""
         raise NotImplementedError()
 
     def get(self, request: HttpRequest) -> HttpResponse:
-        """Download bookings as CSV."""
-        if not self.csv_columns:
-            raise ValueError("DownloadCsv subclass must specify csv_columns")
+        """Download CSV."""
         try:
             self.authorize(request)
         except DownloadForbidden:
             return HttpResponseForbidden()
         return download_csv(
             request.user,
-            self.filename(),
+            self.filename(request),
             self.queryset(request),
-            *self.csv_columns
+            *self.columns(request),
         )

--- a/django_csv/views.py
+++ b/django_csv/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.db.models.query import QuerySet
-from django.http import HttpResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
+from django.views import View
 
 from .csv import write_csv
 from .models import CsvDownload
@@ -21,3 +22,49 @@ def download_csv(
         columns=", ".join(columns),
     )
     return response
+
+
+class DownloadForbidden(Exception):
+    pass
+
+
+class DownloadCsv(View):
+    """CBV for downloading CSVs."""
+
+    # list of columns to be extracted from the queryset
+    csv_columns = []
+
+    def authorize(self, request: HttpRequest) -> None:
+        """
+        Authorize the download request.
+
+        Raise DownloadForbidden if download is not permitted.
+
+        Default is to allow all authenticated users access.
+
+        """
+        if not request.user.is_authenticated:
+            raise DownloadForbidden()
+
+    def filename(self, request: HttpRequest) -> str:
+        """Return download filename."""
+        raise NotImplementedError()
+
+    def queryset(self, request: HttpRequest) -> QuerySet:
+        """Fetch the appropriate data for the user."""
+        raise NotImplementedError()
+
+    def get(self, request: HttpRequest) -> HttpResponse:
+        """Download bookings as CSV."""
+        if not self.csv_columns:
+            raise ValueError("DownloadCsv subclass must specify csv_columns")
+        try:
+            self.authorize(request)
+        except DownloadForbidden:
+            return HttpResponseForbidden()
+        return download_csv(
+            request.user,
+            self.filename(),
+            self.queryset(request),
+            *self.csv_columns
+        )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,7 +4,8 @@ import pytest
 from django.contrib.auth.models import User
 
 from django_csv.models import CsvDownload
-from django_csv.views import download_csv
+from django_csv.views import CsvDownloadView, download_csv
+from tests.views import DownloadUsers
 
 
 @pytest.mark.django_db

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,8 +1,11 @@
 from django.contrib import admin
 from django.urls import path
 
+from tests.views import DownloadUsers
+
 admin.autodiscover()
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("downloads/users.csv", DownloadUsers.as_view()),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -2,13 +2,12 @@ from django.contrib.auth.models import User
 from django.http.request import HttpRequest
 
 from django_csv.csv import QuerySetWriter
-from django_csv.views import DownloadCsvView, DownloadForbidden
+from django_csv.views import CsvDownloadView
 
 
-class DownloadUsers(DownloadCsvView):
-    def authorize(self, request: HttpRequest) -> None:
-        if not request.user.is_staff:
-            raise DownloadForbidden()
+class DownloadUsers(CsvDownloadView):
+    def is_permitted(self, request: HttpRequest) -> bool:
+        return request.user.is_staff
 
     def queryset(self, request: HttpRequest) -> QuerySetWriter:
         return User.objects.all()

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,0 +1,20 @@
+from django.contrib.auth.models import User
+from django.http.request import HttpRequest
+
+from django_csv.csv import QuerySetWriter
+from django_csv.views import DownloadCsvView, DownloadForbidden
+
+
+class DownloadUsers(DownloadCsvView):
+    def authorize(self, request: HttpRequest) -> None:
+        if not request.user.is_staff:
+            raise DownloadForbidden()
+
+    def queryset(self, request: HttpRequest) -> QuerySetWriter:
+        return User.objects.all()
+
+    def filename(self, request: HttpRequest) -> str:
+        return "users.csv"
+
+    def columns(self, request: HttpRequest) -> str:
+        return ("first_name", "last_name")


### PR DESCRIPTION
In projects where a lot of different CSV downloads are permitted, replicating `download_csv` calls can get out of control, and be hard to keep in line. A CBV that formalises the component parts can make this simpler to manage.