### PR TITLE
Upload to S3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
 
     # Flake8 includes pyflakes, pycodestyle, mccabe, pydocstyle, bandit
     - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.8.4
+      rev: 3.9.0
       hooks:
           - id: flake8
             language_version: python3.8
@@ -24,7 +24,7 @@ repos:
 
     # python static type checking
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v0.800
+      rev: v0.812
       hooks:
           - id: mypy
             language_version: python3.8

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ def download_users(request: HttpRequest) -> HttpResponse:
 
 ## Settings
 
-There is a `CSV_DOWNLOAD_MAX_ROWS` setting that is used to truncate output. Defaults to 10000.
+There is a `CSV_DOWNLOAD_MAX_ROWS` setting that is used to truncate output. Defaults to 10000. This is a backstop, and can be overridden on a per use
+basis.
 
 ## Examples
 
@@ -61,6 +62,13 @@ Example of writing to an in-memory text buffer:
 >>> buffer = io.StringIO()
 >>> csv.write_csv(buffer, data, *columns)
 10
+```
+
+Example of writing directly to S3:
+
+```python
+>>> with s3.s3_stream("bucket_name", "object_key") as buffer:
+...     csv.write_csv(buffer, data, *columns)
 ```
 
 Example of a custom admin action to download User data:

--- a/django_csv/csv.py
+++ b/django_csv/csv.py
@@ -30,8 +30,10 @@ Example of writing to an in-memory text buffer:
 
 """
 import csv
+from io import BytesIO, TextIOWrapper
 from typing import Any
 
+import boto3
 from django.db.models import QuerySet
 
 from .settings import MAX_ROWS
@@ -76,3 +78,32 @@ def write_csv(csvfile: Any, queryset: QuerySet, *columns: str) -> int:
     writer.write_header()
     writer.write_rows()
     return writer.row_count
+
+
+def export_to_s3(bucket: str, key: str, queryset: QuerySet, *columns: str) -> int:
+    """
+    Export data as a CSV direct to S3.
+
+    This function uses `boto3`, and relies on the environment settings
+    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, as documented here:
+    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#environment-variables
+
+    """
+    with BytesIO() as csv_bytes:
+        # wrap the bytes with a text wrapper so that csv.writer can use it
+        with TextIOWrapper(
+            csv_bytes,
+            encoding="utf-8",
+            newline="",
+            write_through=True,
+        ) as csv_str:
+            row_count = write_csv(csv_str, queryset, *columns)
+            csv_bytes.seek(0)
+            client = boto3.client("s3")
+            client.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=csv_bytes,
+                ContentType="text/csv",
+            )
+            return row_count

--- a/django_csv/s3.py
+++ b/django_csv/s3.py
@@ -1,0 +1,37 @@
+"""Optional functions for uploading data direct to S3."""
+import contextlib
+from io import BytesIO, TextIOWrapper
+from typing import Generator
+
+try:
+    import boto3
+except ImportError:
+    raise ImportError("You cannot use the django_csv.s3 module without boto3.")
+
+
+def _put_object(bucket: str, key: str, body: BytesIO) -> None:
+    """Upload binary stream to S3 using put_pubject."""
+    client = boto3.client("s3")
+    client.put_object(Bucket=bucket, Key=key, Body=body, ContentType="text/csv")
+
+
+@contextlib.contextmanager
+def s3_stream(bucket: str, key: str) -> Generator:
+    """
+    Return a context manager used to write csv to S3.
+
+    This is a wrapper that provides access to a BytesIO stream (that
+    boto3 can use to push a file to S3) via a TextIO wrapper that
+    csv.writer can use.
+
+    >>> with s3_stream("bucket", "obj_key") as fileobj:
+    ...   write_csv(fileobj, queryset, "col1", "col2")
+
+    """
+    with BytesIO() as binary_stream:
+        with TextIOWrapper(
+            binary_stream, encoding="utf-8", newline="", write_through=True
+        ) as text_stream:
+            yield text_stream
+            binary_stream.seek(0)
+            _put_object(bucket, key, binary_stream)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-csv-downloads"
-version = "0.3"
+version = "0.4.b0"
 description = "Django app for enabling and tracking CSV downloads"
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ packages = [{ include = "django_csv" }]
 [tool.poetry.dependencies]
 python = "^3.8"
 django = "^2.2 || ^3.0"
-boto3 = "^1.17.27"
+boto3 = { version = "^1.17.27", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ packages = [{ include = "django_csv" }]
 [tool.poetry.dependencies]
 python = "^3.8"
 django = "^2.2 || ^3.0"
+boto3 = "^1.17.27"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-csv-downloads"
-version = "0.4.b0"
+version = "0.4"
 description = "Django app for enabling and tracking CSV downloads"
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -50,14 +50,24 @@ class TestQuerySetWriter:
 
 
 @pytest.mark.django_db
-def test_write_csv():
+@pytest.mark.parametrize(
+    "header,max_rows,output_row_count,output_lines",
+    [
+        (True, 100, 3, 4),
+        (False, 100, 3, 3),
+        (True, 1, 1, 2),
+    ],
+)
+def test_write_csv(header, max_rows, output_row_count, output_lines):
     csvfile = StringIO()
     columns = ("first_name", "last_name")
     User.objects.create_user("user1")
     User.objects.create_user("user2")
     User.objects.create_user("user3")
-    row_count = csv.write_csv(csvfile, User.objects.all(), *columns)
+    row_count = csv.write_csv(
+        csvfile, User.objects.all(), *columns, header=header, max_rows=max_rows
+    )
     csvfile.seek(0)
     lines = csvfile.readlines()
-    assert row_count == 3
-    assert len(lines) == 4
+    assert row_count == output_row_count
+    assert len(lines) == output_lines

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,0 +1,22 @@
+from io import BytesIO
+from unittest import mock
+
+import pytest
+from django.contrib.auth.models import User
+
+from django_csv import csv, s3
+
+
+@pytest.mark.django_db
+@mock.patch("django_csv.s3._put_object")
+def test_s3_stream(mock_put):
+    columns = ("first_name", "last_name")
+    User.objects.create_user("user1")
+    with s3.s3_stream("bucket_name", "filename") as fileobj:
+        row_count = csv.write_csv(fileobj, User.objects.all(), *columns)
+        assert row_count == 1
+    assert mock_put.call_count == 1
+    call_args = mock_put.call_args[0]
+    assert call_args[0] == "bucket_name"
+    assert call_args[1] == "filename"
+    assert isinstance(call_args[2], BytesIO)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    djangomaster: https://codeload.github.com/django/django/tar.gz/main
 
 commands =
     pytest --cov=django_csv --verbose tests/

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = fmt, lint, mypy, checks, py{3.8,3.9}-django{22,30,31,master}
 
 [testenv]
 deps =
+    boto3
     coverage
     pytest
     pytest-cov


### PR DESCRIPTION
Fixes #2 

This PR enables the direct upload of csv data to S3, using the `put_object` function.