### PR TITLE
Add support for custom headers

### DIFF
--- a/django_csv/csv.py
+++ b/django_csv/csv.py
@@ -31,7 +31,7 @@ Example of writing to an in-memory text buffer:
 """
 import csv
 import logging
-from typing import Any
+from typing import Any, Iterable
 
 from django.core.paginator import Paginator
 from django.db.models import QuerySet
@@ -69,8 +69,13 @@ class BaseQuerySetWriter:
         """Return the rows to write as a capped values_list queryset."""
         return self.queryset.values_list(*self.columns)[: self.max_rows]
 
-    def write_header(self) -> None:
-        self.writer.writerow(self.columns)
+    def write_header(self, column_headers: list[str] | None = None) -> None:
+        row: Iterable = self.columns
+        if column_headers:
+            if len(column_headers) != len(self.columns):
+                raise ValueError("Columns and headers do not match in length.")
+            row = column_headers
+        self.writer.writerow(row)
 
     def write_rows(self) -> int:
         raise NotImplementedError
@@ -116,9 +121,10 @@ def write_csv(
     *columns: str,
     header: bool = True,
     max_rows: int = MAX_ROWS,
+    column_headers: list[str] | None = None,
 ) -> int:
     """Write QuerySet to fileobj in CSV format using BulkQuerySetWriter."""
     writer = BulkQuerySetWriter(fileobj, queryset, *columns, max_rows=max_rows)
     if header:
-        writer.write_header()
+        writer.write_header(column_headers=column_headers)
     return writer.write_rows()

--- a/django_csv/csv.py
+++ b/django_csv/csv.py
@@ -31,12 +31,13 @@ Example of writing to an in-memory text buffer:
 """
 import csv
 import logging
-from typing import Any, Iterable
+from typing import Any, Sequence
 
 from django.core.paginator import Paginator
 from django.db.models import QuerySet
 
 from .settings import DEFAULT_PAGE_SIZE, MAX_ROWS
+from .types import OptionalSequence
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +70,8 @@ class BaseQuerySetWriter:
         """Return the rows to write as a capped values_list queryset."""
         return self.queryset.values_list(*self.columns)[: self.max_rows]
 
-    def write_header(self, column_headers: list[str] | None = None) -> None:
-        row: Iterable = self.columns
+    def write_header(self, column_headers: OptionalSequence = None) -> None:
+        row: Sequence = self.columns
         if column_headers:
             if len(column_headers) != len(self.columns):
                 raise ValueError("Columns and headers do not match in length.")
@@ -121,7 +122,7 @@ def write_csv(
     *columns: str,
     header: bool = True,
     max_rows: int = MAX_ROWS,
-    column_headers: list[str] | None = None,
+    column_headers: OptionalSequence = None,
 ) -> int:
     """Write QuerySet to fileobj in CSV format using BulkQuerySetWriter."""
     writer = BulkQuerySetWriter(fileobj, queryset, *columns, max_rows=max_rows)

--- a/django_csv/types.py
+++ b/django_csv/types.py
@@ -1,4 +1,4 @@
 from typing import Sequence, Union
 
 # optional list/tuple of columns / headers
-COLUMN_TYPE = Union[Sequence, None]
+OptionalSequence = Union[Sequence, None]

--- a/django_csv/views.py
+++ b/django_csv/views.py
@@ -9,6 +9,7 @@ from django.views import View
 from .csv import write_csv
 from .models import CsvDownload
 from .settings import MAX_ROWS
+from .types import OptionalSequence
 
 
 def download_csv(
@@ -18,7 +19,7 @@ def download_csv(
     *columns: str,
     header: bool = True,
     max_rows: int = MAX_ROWS,
-    column_headers: list[str] | None = None,
+    column_headers: OptionalSequence = None,
 ) -> HttpResponse:
     """Download queryset as a CSV."""
     response = HttpResponse(content_type="text/csv")
@@ -75,7 +76,7 @@ class CsvDownloadView(View):
         """Return columns to extract from the queryset."""
         raise NotImplementedError
 
-    def get_column_headers(self, request: HttpRequest) -> list[str]:
+    def get_column_headers(self, request: HttpRequest) -> List[str]:
         """Return column headers to apply to the CSV."""
         return self.get_columns(request)
 

--- a/django_csv/views.py
+++ b/django_csv/views.py
@@ -18,6 +18,7 @@ def download_csv(
     *columns: str,
     header: bool = True,
     max_rows: int = MAX_ROWS,
+    column_headers: list[str] | None = None,
 ) -> HttpResponse:
     """Download queryset as a CSV."""
     response = HttpResponse(content_type="text/csv")
@@ -28,6 +29,7 @@ def download_csv(
         *columns,
         header=header,
         max_rows=max_rows,
+        column_headers=column_headers,
     )
     response["X-Row-Count"] = row_count
     CsvDownload.objects.create(
@@ -73,6 +75,10 @@ class CsvDownloadView(View):
         """Return columns to extract from the queryset."""
         raise NotImplementedError
 
+    def get_column_headers(self, request: HttpRequest) -> list[str]:
+        """Return column headers to apply to the CSV."""
+        return self.get_columns(request)
+
     def get_queryset(self, request: HttpRequest) -> QuerySet:
         """Return the data to be downloaded."""
         raise NotImplementedError
@@ -89,4 +95,5 @@ class CsvDownloadView(View):
             *self.get_columns(request),
             header=self.add_header(request),
             max_rows=self.get_max_rows(request),
+            column_headers=self.get_column_headers(request),
         )

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -9,8 +9,9 @@ admin.site.unregister(User)
 
 @admin.register(User)
 class CustomUserAdmin(UserAdmin):
-    actions = ["download", "download_without_header"]
+    actions = ["download", "download_without_header", "download_with_custom_header"]
     csv_fields = ("first_name", "last_name", "email", "is_staff")
+    csv_header = ("given name", "family name", "email", "is_staff")
 
     @admin.action(description="Download users (default)")
     def download(self, request, queryset):
@@ -33,4 +34,12 @@ class CustomUserAdmin(UserAdmin):
             header=False,
         )
 
-    download.short_description = "Download selected users"
+    @admin.action(description="Download users (custom header)")
+    def download_with_custom_header(self, request, queryset):
+        return download_csv(
+            request.user,
+            "users.csv",
+            queryset,
+            *self.csv_fields,
+            column_headers=self.csv_header,
+        )

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -72,3 +72,40 @@ def test_write_csv(header, max_rows, output_row_count, output_lines):
     lines = csvfile.readlines()
     assert row_count == output_row_count
     assert len(lines) == output_lines
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "column_headers,header_row",
+    [
+        (None, "first_name,last_name"),
+        (["given_name", "family_name"], "given_name,family_name"),
+    ],
+)
+def test_write_csv__column_headers(column_headers, header_row):
+    csvfile = StringIO()
+    columns = ("first_name", "last_name")
+    column_headers = column_headers
+    _ = csv.write_csv(
+        csvfile,
+        User.objects.all(),
+        *columns,
+        column_headers=column_headers,
+    )
+    csvfile.seek(0)
+    header = csvfile.readline().strip()
+    assert header == header_row
+
+
+@pytest.mark.django_db
+def test_write_csv__column_headers__mismatch():
+    csvfile = StringIO()
+    columns = ("first_name", "last_name")
+    column_headers = ("foo", "bar", "baz")
+    with pytest.raises(ValueError):
+        csv.write_csv(
+            csvfile,
+            User.objects.all(),
+            *columns,
+            column_headers=column_headers,
+        )

--- a/tests/views.py
+++ b/tests/views.py
@@ -23,3 +23,6 @@ class DownloadUsers(CsvDownloadView):
 
     def get_columns(self, request: HttpRequest) -> List[str]:
         return ("first_name", "last_name")
+
+    def get_column_headers(self, request: HttpRequest) -> list[str] | None:
+        return ("given_name", "family_name")

--- a/tests/views.py
+++ b/tests/views.py
@@ -24,5 +24,5 @@ class DownloadUsers(CsvDownloadView):
     def get_columns(self, request: HttpRequest) -> List[str]:
         return ("first_name", "last_name")
 
-    def get_column_headers(self, request: HttpRequest) -> list[str] | None:
+    def get_column_headers(self, request: HttpRequest) -> List[str]:
         return ("given_name", "family_name")


### PR DESCRIPTION
Fixes #8 

This adds in a kwargs `column_headers` in various places to allow the headers in the output CSV to vary from the column names. The number of column headers must match the number of columns.

In addition to the tests I have updated the admin demo:

<img width="569" alt="Screenshot 2023-02-28 at 09 44 19" src="https://user-images.githubusercontent.com/200944/221814964-c1f867e6-af11-4d95-9b31-97d5b654509c.png">

### Default:

first_name|last_name|email|is_staff
---|---|---|---
Hugo|RB|hugo@example.com|True

### Custom header:

given name|family name|email|is_staff
---|---|---|---
Hugo|RB|hugo@example.com|True
