### PR TITLE
Improve performance of RowQuerySetWriter

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -75,6 +75,8 @@ jobs:
           - python: "3.10"
             django: "main"
           - python: "3.11"
+            django: "main"
+          - python: "3.11"
             django: "32"
           - python: "3.12"
             django: "32"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 line-length = 88
-ignore = [
+lint.ignore = [
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
@@ -22,7 +22,7 @@ ignore = [
     "D417",
     "D417",  # Missing argument description in the docstring
 ]
-select = [
+lint.select = [
     "A",  # flake8 builtins
     "C9", # mcabe
     "D",  # pydocstyle
@@ -34,13 +34,13 @@ select = [
     "W",  # pycodestype (warnings)
 ]
 
-[isort]
+[lint.isort]
 combine-as-imports = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 8
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*tests/*" = [
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.3.1
+
+* Improves performance of `RowQuerySetWriter` by avoiding a call to `.count()`
+  on the queryset.
+
 ## v1.3
 
 * Add Django 4.2, 5.0 to classifiers and build matrix

--- a/django_csv/s3.py
+++ b/django_csv/s3.py
@@ -1,4 +1,5 @@
 """Optional functions for uploading data direct to S3."""
+
 import contextlib
 from io import BytesIO, TextIOWrapper
 from tempfile import TemporaryFile

--- a/django_csv/sftp.py
+++ b/django_csv/sftp.py
@@ -1,4 +1,5 @@
 """SFTP upload functions."""
+
 import contextlib
 import io
 import tempfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-csv-downloads"
-version = "1.3"
+version = "1.3.1"
 description = "Django app for enabling and tracking CSV downloads"
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -35,6 +35,7 @@ django = "^3.2 || ^4.0 || ^5.0"
 boto3 = { version = "*", optional = true }
 paramiko = {version = "*", optional = true}
 types-paramiko = "^3.3.0.0"
+ruff = "^0.11.2"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
     django41-py{38,39,310,311}
     django42-py{38,39,310,311}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    djangomain-py{312}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     ruff
 
 commands =
-    ruff django_csv
+    ruff check
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
## Summary

This PR aims to improve the performance of `create_csv` when the `RowQuerySetWriter` class is being used.

### What is the problem?

Unlike the other writer-classes that the library uses this class uses the queryset `iterator()` to save on the overhead of keeping all rows in memory. The necessary side-effect of this is that django doesn't populate the queryset's results cache (since the whole point of using the iterator is to save on memory).

When you call `.count()` on a queryset, if the queryset has a cahced result, it just calls `len()` on that cache to save on an unnecessary database hit. This is what happens for all other writer-classes in the library, however for `RowQuerySetWriter` it needs to run a `COUNT`. For postgres, this can be just as expensive as fetching the whole table. (In fact profiling shows that often the count can take as long, and sometimes even longer than fetching the actual data for the rows).

### What is the solution?

A counter is simple but effective in this case. I did consider evaluating the length of `self.writer`, but this returns the total length of all calls to `write_rows()` - which is not the current behaviour.

### Other changes
- formatting changes required by the latest version of black
- CI was failing because `ruff` has changed the syntax for its CLI. This has been updated in our workflow files
- I have also updated the `ruff.toml` file (since the previous syntax was deprecated).
- I have bumped the version, and updated the change-log
- The development version of django now requires a minimum python version of 3.12, so I have updated the tox grid to reflect this.