### PR TITLE
Misc: Django 5.2 update

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -61,25 +61,25 @@ jobs:
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        # build LTS version, stable versions, and main
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.8"
             django: "50"
           - python: "3.8"
+            django: "52"
+          - python: "3.8"
             django: "main"
           - python: "3.9"
             django: "50"
+          - python: "3.9"
+            django: "52"
           - python: "3.9"
             django: "main"
           - python: "3.10"
             django: "main"
           - python: "3.11"
             django: "main"
-          - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: "v0.1.5"
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [check, --fix, --exit-non-zero-on-fix]
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.0
+
+* Add Django 5.2 support
+* Drop support for Django versions before 4.2
+* Update ruff configuration to use "ruff check" syntax
+* Update GitHub Actions to only test Django main with Python 3.12+
+
 ## v1.3.1
 
 * Improves performance of `RowQuerySetWriter` by avoiding a call to `.count()`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Django app for tracking queryset-backed CSV downloads
 ### Version support
 
 The current version of the this app support **Python 3.8+** and **Django
-3.2+**
+4.2+**
 
 ## What does this app do?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-csv-downloads"
-version = "1.3.1"
+version = "1.4.0"
 description = "Django app for enabling and tracking CSV downloads"
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -13,11 +13,9 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
@@ -31,7 +29,7 @@ packages = [{ include = "django_csv" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^3.2 || ^4.0 || ^5.0"
+django = "^4.2 || ^5.0"
 boto3 = { version = "*", optional = true }
 paramiko = {version = "*", optional = true}
 types-paramiko = "^3.3.0.0"

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,9 @@ envlist =
     fmt, lint, mypy,
     django-checks,
     ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{38,39,310}
-    django40-py{38,39,310}
-    django41-py{38,39,310,311}
     django42-py{38,39,310,311}
     django50-py{310,311,312}
+    django52-py{310,311,312}
     djangomain-py{312}
 
 [testenv]
@@ -19,11 +17,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
# Add Django 5.2 Support and Modernize Configuration
This PR adds support for Django 5.2 while also making several maintenance updates.

## Changes

1. Added Django 5.2 compatibility: Updated tox configuration and GitHub workflow to include Django 5.2 testing
2. Dropped Support for Django < 4.2: Removed Django 3.2, 4.0, and 4.1 support as they're approaching EOL or already unsupported
3. Updated GitHub Actions Workflow: Configured to only test Django main branch on Python 3.12+
4. Modernized Ruff Configuration: Updated pre-commit hooks to use the modern ruff check syntax
5. Version Bump: Increased version from 1.3.1 to 1.4.0 to reflect the significant compatibility changes
6. Updated Documentation: README and classifier tags now correctly reflect the supported versions